### PR TITLE
[22] Actualizar ETL para campeonato 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 /node_modules
 /public/images/
 .env
-cargaCuboResultados_0.1.zip
-cargaCuboResultados2016_0.1.zip
+cargaCuboResultados*.zip
 composer.lock
 ansible/external-roles/
 database/scripts/carga plantillas 2016.sql

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,5 +1,6 @@
 Instrucciones para actualizar ETL
 
 sudo ansible-galaxy install -r requirements.yml
+
 ansible-playbook site.yml --ask-sudo-pass -s -u drevelo -i allservers.yml -l production
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -82,7 +82,7 @@
   become_method: sudo
   become: yes
   file:
-    path: "{{ full_path }}/cargaCuboResultados2016/cargaCuboResultados2016_run.sh"
+    path: "{{ full_path }}/{{ etl_name }}/{{ etl_name }}_run.sh"
     mode: u=rwx,g=rwx,o=x
   tags:
     - etl

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -8,7 +8,7 @@
     - directory: etl
     - full_path: "{{ path }}/{{ directory }}"
     - deploy_user: drevelo
-    - etl_name: cargaCuboResultados2016
+    - etl_name: cargaCuboResultados2017
     - zip_file: "{{ etl_name }}_0.1.zip"
   roles:
     - williamyeh.oracle-java


### PR DESCRIPTION
Este PR hace referencia al issue #22 

Actualiza el playbook de ansible para cargar la ETL que llena los torneos de la serie A y B 2017
